### PR TITLE
GCS-URL

### DIFF
--- a/lib/paperclip/gcs/version.rb
+++ b/lib/paperclip/gcs/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   module Gcs
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/paperclip/storage/gcs.rb
+++ b/lib/paperclip/storage/gcs.rb
@@ -122,6 +122,11 @@ module Paperclip
           raise ArgumentError, "missing required :gcs_bucket option"
       end
 
+      # GCS_URL: turn the Paperclip style url into one that google references.
+      def gcs_url(style = :original, include_timestamp = false)
+        "gs:#{self.url(style.to_sym, timestamp: include_timestamp).gsub("storage.googleapis.com/","")}"
+      end # gcs_url
+
       private
 
       def normalize_style(opts)


### PR DESCRIPTION
Adds the ability to access a formatted url for Google cloud services natively.

Allows the calling of ```model_object.file.gcs_url``` to get a url in the form of ```gs://...``` for ease of use.