### PR TITLE
Switch to official fork of paperclip

### DIFF
--- a/paperclip-gcs.gemspec
+++ b/paperclip-gcs.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "paperclip", ">= 4.0"
+  spec.add_runtime_dependency "kt-paperclip", ">= 4.0"
   spec.add_runtime_dependency "google-cloud-storage", "~> 1.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
thoughtbot/paperclip has been deprecated for a while now, and points to https://github.com/kreeti/kt-paperclip instead, which is actively maintained