### PR TITLE
Fix Ruby3 syntax error in calls to GCS storage

### DIFF
--- a/lib/paperclip/storage/gcs.rb
+++ b/lib/paperclip/storage/gcs.rb
@@ -80,7 +80,7 @@ module Paperclip
             storage_class: gcs_storage_class(style),
             metadata: gcs_metadata(style),
           }
-          gcs_bucket.upload_file(file.path, path(style), opts)
+          gcs_bucket.upload_file(file.path, path(style), **opts)
         end
         after_flush_writes
         @queued_for_write = {}

--- a/lib/paperclip/storage/gcs/client_repository.rb
+++ b/lib/paperclip/storage/gcs/client_repository.rb
@@ -14,7 +14,7 @@ module Paperclip
           clients[config] ||= Google::Cloud.storage(
             config[:project],
             config[:keyfile],
-            config.slice(:scope, :retries, :timeout)
+            **config.slice(:scope, :retries, :timeout)
           )
         end
 


### PR DESCRIPTION
Since Ruby 3.0.0, passing keyword arguments as the last hash parameter isn't supported anymore, and we need to use the double splat operator to expand the hash to a list of arguments instead. 
Cf https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ for more details.

Luckily the double splat operator has been around since Ruby 2.0.0 released about 10 years ago, so this should be a pretty safe change from a backward compatibility point of view.