### PR TITLE
feat: respect gcs hostname

### DIFF
--- a/lib/paperclip/storage/gcs.rb
+++ b/lib/paperclip/storage/gcs.rb
@@ -170,7 +170,9 @@ module Paperclip
 
       def gcs_client
         @_gcs_client ||= ClientRepository.find(gcs_credentials.slice(:project, :keyfile).merge(
-                                                 @gcs_options.slice(:scope, :retries, :timeout)))
+                                                 @gcs_options.slice(:scope, :retries, :timeout)).merge(
+                                                  @options.slice(:gcs_host_name)
+                                                 ))
       end
 
       def gcs_bucket

--- a/lib/paperclip/storage/gcs/client_repository.rb
+++ b/lib/paperclip/storage/gcs/client_repository.rb
@@ -1,3 +1,5 @@
+require "google/cloud/storage"
+
 module Paperclip
   module Storage
     module Gcs
@@ -11,9 +13,10 @@ module Paperclip
         end
 
         def find(config)
-          clients[config] ||= Google::Cloud.storage(
-            config[:project],
-            config[:keyfile],
+          clients[config] ||= Google::Cloud::Storage.new(
+            project_id: config[:project],
+            credentials: config[:keyfile],
+            endpoint: config[:gcs_host_name],
             **config.slice(:scope, :retries, :timeout)
           )
         end


### PR DESCRIPTION
This change uses the GCS hostname specified in the base config for the storage client to ensure the GCS hostname is respected for all usage throughout this gem.